### PR TITLE
Consertada página de remoção de produtos, melhorada página de alteração de produtos

### DIFF
--- a/website/alteracao_produto.php
+++ b/website/alteracao_produto.php
@@ -8,7 +8,11 @@
     $select_product = $connection->prepare('select * from tbl_produto where id_produto = ' . $_GET['id']);
     $select_product->execute();
     $result = $select_product->fetch(PDO::FETCH_ASSOC);
-    
+    if($result == NULL) {
+        echo "Produto não encontrado! Redirecionando para a página de produtos...";
+        header('Refresh: 3; url=./produtos.php');
+        die();
+    }
 ?>
 <!DOCTYPE html>
 <html lang="pt-BR">

--- a/website/remocao_produto.php
+++ b/website/remocao_produto.php
@@ -16,14 +16,14 @@
         <form method='post' action='./remocao_produto.php' id='formDelProduto'>
         <label for='confirm'>VOCÊ TEM CERTEZA?</label>
             <input type='checkbox' name='confirm' required>
-            <input type='hidden' name='delete' value=" . $_POST['delete'] . ">
+            <input type='hidden' name='delete' value="<?php echo $_POST['delete'] ?>">
             <input type='submit' value='Excluir'>
             <input type='button' value='Cancelar' onclick='window.history.back()'>
         </form>
     </body>
 </html>
 <?php
-    if(!isset($_POST['confirm'] || !$_POST['confirm'])) {
+    if(!isset($_POST['confirm']) || !$_POST['confirm']) {
         die();
     }
     $connection = connect();


### PR DESCRIPTION
Tinha feito bosta no último merge; alterei a página de remoção e esqueci de um parênteses e um <?php ?>;
Página de alteração de produtos agora verifica se o ID é válido